### PR TITLE
bind to :::{port} instead of 0.0.0.0:port

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -226,7 +226,7 @@ impl AfterMiddleware for CorsMiddleware {
 
 fn server(config: &Config, stats: SyncSender<CargoRequest>) {
     // web server to handle DL requests
-    let host = format!("0.0.0.0:{}", config.port);
+    let host = format!(":::{}", config.port);
     let router = router!(
         stats_json: get "/stats.json" => {
                 move |_request: &mut Request|


### PR DESCRIPTION
by binding to ::, we handle both IPv4 and IPv4 situations